### PR TITLE
Use the NPM registry for NPM installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Lightweight wrapper for littleBits Cloud HTTP API
 ## Installation
 
 ```
-npm install --save @littlebits/cloud-http
+npm install --save littlebits-cloud-http
 ```
 
 


### PR DESCRIPTION
I suggest we use the NPM registry for NPM installs.
The command specified in the README doesn't work.

In the new NPM version, the `@` is deprecated and I believe it should be `cloud-client-api-http`  not `cloud-http`. :)
